### PR TITLE
Ensure arrow colliders are triggers

### DIFF
--- a/Assets/Scripts/UI/TileChoiceUi.cs
+++ b/Assets/Scripts/UI/TileChoiceUi.cs
@@ -43,6 +43,7 @@ public class TileChoiceUI : MonoBehaviour
             {
                 col = arrow.AddComponent<BoxCollider>();
             }
+            col.isTrigger = true;
 
             // Ensure Rigidbody is present and set to kinematic (required for EventSystem to detect physics events)
             Rigidbody rb = arrow.GetComponent<Rigidbody>();


### PR DESCRIPTION
## Summary
- Set arrow colliders in tile chooser as triggers so pointer events pass through

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6897f5330e7c832f92e5b41b90eadf2d